### PR TITLE
feat(ble): allow dongle without Bluetooth profiles

### DIFF
--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -162,6 +162,13 @@ bool zmk_ble_active_profile_is_connected(void) {
     advertising_status = ZMK_ADV_CONN;
 
 int update_advertising(void) {
+#if IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
+    if (CONFIG_ZMK_SPLIT_BLE_CENTRAL_PERIPHERALS == CONFIG_BT_MAX_CONN) {
+        LOG_INF("skipped advertising, no connections allocated for profiles");
+        return 0;
+    }
+#endif
+
     int err = 0;
     bt_addr_le_t *addr;
     struct bt_conn *conn;


### PR DESCRIPTION
Allow setting CONFIG_BT_MAX_CONN to CONFIG_ZMK_SPLIT_BLE_CENTRAL_PERIPHERALS for dongle mode without Bluetooth profiles (USB output only).

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
